### PR TITLE
Implement a global staff channel

### DIFF
--- a/DiscordClass.js
+++ b/DiscordClass.js
@@ -28,11 +28,10 @@ class DiscordMessager extends EventEmitter{
         let chatMap = fs.readFileSync('./chatMap.json')
         this.chatMap = JSON.parse(chatMap)
         this.globalChannel = this.chatMap.find(channel => channel.name == "global")
+        this.globalStaffChannel = this.chatMap.find(channel => channel.name == "global-staff")
 
         //setup a webhook to send to the mapped channels if it's not already set up
         for(let channel of this.chatMap){
-            if(channel.webhookId) continue;
-            //check if the channel has a webhook
             this.client.channels.cache.get(channel.channelId).fetchWebhooks().then(webhooks => {
                 //if it has a webhook, check if it's the correct name, it should have the name "Devious Messager"
                 let webhook = webhooks.find(webhook => webhook.name == "Devious Messager")
@@ -53,6 +52,11 @@ class DiscordMessager extends EventEmitter{
 
         //initialize message listener and event emitter
         this.client.on('messageCreate', (message) => {
+            if(message.channelId == this.globalStaffChannel.channelId){
+                //ignore bot messages
+                if(message.author.bot) return
+                this.emit('globalStaffMessage', message)
+            }
             if (message.channelId == this.globalChannel.channelId) {
                 //ignore bot messages
                 if (message.author.bot) return

--- a/index.js
+++ b/index.js
@@ -64,6 +64,18 @@ client.on("ready", async() => {
         global.discordMessager.sendToGlobal(`[${server}] ${message.content}`, message.author.username, message.author.avatarURL())
     })
 
+    global.discordMessager.on("globalStaffMessage", (message) => {
+        Object.values(global.wssConnectedPeers).forEach(peer => {
+            peer.socket.send(JSON.stringify({
+                event: "message",
+                username: message.author.username,
+                channel: "server",
+                serverName: "Announcement",
+                message: message.content
+            }))
+        })
+    })
+
     setTimeout(() => {
         global.playerCount = 0 
         for(let peer of Object.values(global.wssConnectedPeers)){


### PR DESCRIPTION
Fixes #15

Added a new global staff channel for staff members to communicate with all servers. When a message is received in the global staff channel, the bot will ignore any messages sent by bots and emit an event called 'globalStaffMessage'. In the 'index.js' file, a new listener has been added to handle the 'globalStaffMessage' event. When the event is triggered, the bot will send the message to all connected peers via WebSocket.